### PR TITLE
fix: handle usage of keyPrefix in useTranslation setup

### DIFF
--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -79,9 +79,19 @@ module.exports = {
 
           const ancestors = context.sourceCode.getAncestors(node);
           let prefix = null;
-          ancestors?.map(ancestor => ancestor.body?.length > 0 && ancestor.body.map(body => body.declarations?.length > 0 && body.declarations.map(declaration => {
-            if (declaration.init?.callee.name === 'useTranslation') prefix = declaration.init?.arguments[1].properties[0].value.value;
-          })));
+          ancestors?.forEach(ancestor => {
+            if (ancestor.body?.length > 0) {
+              ancestor.body.forEach(body => {
+                if (body.declarations?.length > 0) {
+                  body.declarations.forEach(declaration => {
+                    if (declaration.init?.callee.name === 'useTranslation') {
+                      prefix = declaration.init?.arguments[1].properties?.[0].value.value
+                    }
+                  })
+                }
+              })
+            }
+          });
 
           const key = prefix ? [prefix, node.arguments?.[0]?.value].join('.') : node.arguments?.[0]?.value;
           const keyWithoutNamespace = key.indexOf(':') === -1 ? key : key.slice(key.indexOf(':') + 1);

--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -79,20 +79,11 @@ module.exports = {
 
           const ancestors = context.sourceCode.getAncestors(node);
           let prefix = null;
-
-          // with getText()
-          const texts = context.sourceCode.getText(ancestors[0]);
-          if (texts.match(/keyPrefix/)) {
-              prefix = texts.split('keyPrefix: \'').pop().split('\'')[0];
-            }
-
-          // with getAncestors()
-          // ancestors?.map(ancestor => ancestor.body?.length > 0 && ancestor.body.map(body => body.declarations?.length > 0 && body.declarations.map(declaration => {
-          //   if (declaration.init?.callee.name === 'useTranslation') prefix = declaration.init?.arguments[1].properties[0].value.value;
-          // })));
+          ancestors?.map(ancestor => ancestor.body?.length > 0 && ancestor.body.map(body => body.declarations?.length > 0 && body.declarations.map(declaration => {
+            if (declaration.init?.callee.name === 'useTranslation') prefix = declaration.init?.arguments[1].properties[0].value.value;
+          })));
 
           const key = prefix ? [prefix, node.arguments?.[0]?.value].join('.') : node.arguments?.[0]?.value;
-          console.log(key);
           const keyWithoutNamespace = key.indexOf(':') === -1 ? key : key.slice(key.indexOf(':') + 1);
           const namespace = (key === keyWithoutNamespace) ? defaultNamespace : key.slice(0, key.indexOf(':'));
 

--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -85,11 +85,11 @@ module.exports = {
                 if (body.declarations?.length > 0) {
                   body.declarations.forEach(declaration => {
                     if (declaration.init?.callee.name === 'useTranslation') {
-                      prefix = declaration.init?.arguments[1].properties?.[0].value.value
+                      prefix = declaration.init?.arguments[1]?.properties[0]?.value?.value;
                     }
-                  })
+                  });
                 }
-              })
+              });
             }
           });
 

--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -77,7 +77,22 @@ module.exports = {
             return;
           }
 
-          const key = node.arguments?.[0]?.value
+          const ancestors = context.sourceCode.getAncestors(node);
+          let prefix = null;
+
+          // with getText()
+          const texts = context.sourceCode.getText(ancestors[0]);
+          if (texts.match(/keyPrefix/)) {
+              prefix = texts.split('keyPrefix: \'').pop().split('\'')[0];
+            }
+
+          // with getAncestors()
+          // ancestors?.map(ancestor => ancestor.body?.length > 0 && ancestor.body.map(body => body.declarations?.length > 0 && body.declarations.map(declaration => {
+          //   if (declaration.init?.callee.name === 'useTranslation') prefix = declaration.init?.arguments[1].properties[0].value.value;
+          // })));
+
+          const key = prefix ? [prefix, node.arguments?.[0]?.value].join('.') : node.arguments?.[0]?.value;
+          console.log(key);
           const keyWithoutNamespace = key.indexOf(':') === -1 ? key : key.slice(key.indexOf(':') + 1);
           const namespace = (key === keyWithoutNamespace) ? defaultNamespace : key.slice(0, key.indexOf(':'));
 


### PR DESCRIPTION
I have both implementation on `getText()` and `getAncestors` on `node` passing `calle.name === 't'`, to be continued.