### PR TITLE
feat(LMA-1692): detect plural suffixes as valid definition for key

### DIFF
--- a/lib/lang/en.json
+++ b/lib/lang/en.json
@@ -2,5 +2,9 @@
   "pizza": "pizza",
   "records": {
     "contracts": "Contracts"
+  },
+  "distance": {
+    "milesAway_one": "x",
+    "milesAway_other": "y"
   }
 }

--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -10,6 +10,8 @@ const requireNoCache = require('../requireNoCache');
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const possiblePluralSuffixes = ['zero', 'singular', 'one', 'two', 'few', 'many', 'other'];
+
 /**
  * @type {import('eslint').Rule.RuleModule}
  */
@@ -60,6 +62,17 @@ module.exports = {
       while(arr.length) {
         const keyToAccess = arr.shift();
         obj = obj?.[keyToAccess];
+
+        /* If we're at the last key segment and appear to have a miss,
+        * let's try the plural suffixes */
+        if (!arr.length && !obj && keyToAccess) {
+          for (let i = 0; i < possiblePluralSuffixes.length; i++) {
+            obj = obj?.[`${keyToAccess}_${possiblePluralSuffixes[i]}`];
+            if (obj) {
+              break;
+            }
+          }
+        }
       }
       return obj;
     }

--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -61,13 +61,14 @@ module.exports = {
       const arr = key.split(".");
       while(arr.length) {
         const keyToAccess = arr.shift();
+        const prevObj = obj;
         obj = obj?.[keyToAccess];
 
         /* If we're at the last key segment and appear to have a miss,
         * let's try the plural suffixes */
         if (!arr.length && !obj && keyToAccess) {
           for (let i = 0; i < possiblePluralSuffixes.length; i++) {
-            obj = obj?.[`${keyToAccess}_${possiblePluralSuffixes[i]}`];
+            obj = prevObj?.[`${keyToAccess}_${possiblePluralSuffixes[i]}`];
             if (obj) {
               break;
             }

--- a/tests/lib/rules/no-undefined-translation-keys.js
+++ b/tests/lib/rules/no-undefined-translation-keys.js
@@ -25,6 +25,9 @@ ruleTester.run("no-undefined-translation-keys", rule, {
     {
       code: "t('records.contracts')"
     }
+    {
+      code: "t('distance.milesAway')"
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/no-undefined-translation-keys.js
+++ b/tests/lib/rules/no-undefined-translation-keys.js
@@ -24,7 +24,7 @@ ruleTester.run("no-undefined-translation-keys", rule, {
     },
     {
       code: "t('records.contracts')"
-    }
+    },
     {
       code: "t('distance.milesAway')"
     },


### PR DESCRIPTION
This PR expands the `no-undefined-translation-keys` rule to detect keys with plural suffixes as a valid definition for the root key.  i.e. if there is `milesAway_one` or `milesAway_other`, the key `milesAway` would be considered defined, and the lint rule would not throw an error.