### PR TITLE
A fix for the translations with periods and colons

### DIFF
--- a/lib/rules/no-undefined-translation-keys.js
+++ b/lib/rules/no-undefined-translation-keys.js
@@ -58,7 +58,9 @@ module.exports = {
 
     function getTranslationKey(namespace, key) {
       let obj = translationKeysFromFiles[namespace];
+
       const arr = key.split(".");
+
       while(arr.length) {
         const keyToAccess = arr.shift();
         const prevObj = obj;
@@ -69,12 +71,22 @@ module.exports = {
         if (!arr.length && !obj && keyToAccess) {
           for (let i = 0; i < possiblePluralSuffixes.length; i++) {
             obj = prevObj?.[`${keyToAccess}_${possiblePluralSuffixes[i]}`];
+
             if (obj) {
               break;
             }
           }
         }
       }
+
+      if (!obj) {
+        const directTranslation = translationKeysFromFiles[namespace]?.[key];
+
+        if (typeof directTranslation === 'string') {
+          obj = directTranslation;
+        }
+      }
+
       return obj;
     }
 
@@ -111,9 +123,10 @@ module.exports = {
 
           const key = prefix ? [prefix, node.arguments?.[0]?.value].join('.') : node.arguments?.[0]?.value;
           const keyWithoutNamespace = key.indexOf(':') === -1 ? key : key.slice(key.indexOf(':') + 1);
+          
           namespace = (key === keyWithoutNamespace) ? (namespace ?? defaultNamespace) : key.slice(0, key.indexOf(':'));
 
-          if (getTranslationKey(namespace, keyWithoutNamespace) === undefined) {
+          if (getTranslationKey(namespace, keyWithoutNamespace) === undefined && getTranslationKey(defaultNamespace, key) === undefined) {
             context.report({
               node: node,
               message: `Translation key "${keyWithoutNamespace}" in namespace "${namespace}" is used here but missing in the translations file.`


### PR DESCRIPTION
Currently, if a translation key has a period or a colon, it will throw an error, because they are treated as separators for namespaces or nested translations. I added a fallback check, so if the nested or namespace translations are not found, we try to access the key literally.